### PR TITLE
Absorb astropy-changelog logic so that package is no longer a dependency; other updates

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit =
+    # This is only called from GHA
+    check_changelog.py
+    # Tests
+    test_*.py

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+# E501: line too long
+ignore = E501

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -18,8 +18,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-    - name: Install test dependencies
-      run: pip install flake8 pytest pytest-cov --upgrade
+    - name: Install dependencies
+      run: pip install docutils flake8 pytest pytest-cov --upgrade
     - name: Tests
       run: |
         flake8 *.py

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         python-version: '3.11'
     - name: Install test dependencies
-      run: pip install pytest pytest-cov --upgrade
+      run: pip install flake8 pytest pytest-cov --upgrade
     - name: Tests
       run: |
         flake8 *.py

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # Weekly Thursday 5AM build
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 5 * * 4'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install test dependencies
+      run: pip install pytest pytest-cov --upgrade
+    - name: Tests
+      run: |
+        flake8 *.py
+        pytest --cov=./ --cov-report=xml
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage.xml
+        verbose: true

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -22,7 +22,7 @@ jobs:
       run: pip install docutils flake8 pytest pytest-cov --upgrade
     - name: Tests
       run: |
-        flake8 *.py
+        flake8 *.py --count
         pytest --cov=./ --cov-report=xml
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,11 +33,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -48,7 +48,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -62,4 +62,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,25 @@
-# Container image that runs your code
-FROM quay.io/spacetelescope/astropy-actions-docker:0.1
+# Container image that runs your code.
+# NOTE: Could speed things up if you use an existing image with all the
+#       deps pre-installed but still not as fast as TypeScript.
+FROM ubuntu:22.04
+
+RUN apt-get update \
+    && apt-get install -y \
+    build-essential \
+    python3-pip \
+    python3.11 \
+    git \
+    && python3 -m pip install --upgrade pip \
+    && python3 -m pip install --upgrade setuptools \
+    && python3 -m pip install --upgrade wheel \
+    && python3 -m pip install PyGithub \
+    && python3 -m pip install docutils
 
 # Copies code file action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 
+COPY core.py /core.py
+COPY rst_parser.py /rst_parser.py
 COPY check_changelog.py /check_changelog.py
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && apt-get install -y \
     build-essential \
     python3-pip \
-    python3.11 \
+    python3.10 \
     git \
     && python3 -m pip install --upgrade pip \
     && python3 -m pip install --upgrade setuptools \

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ BSD 3-Clause License
 
 Copyright (c) 2023, Scientific Python Developers
 Copyright (c) 2020-2023, P. L. Lim
+Copyright (c) 2018-2023, Thomas P. Robitaille
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GitHub Action to check if change log entry conforms to given rules in plain text file
 
+[![CI Status](https://github.com/scientific-python/action-check-changelogfile/workflows/CI/badge.svg)](https://github.com/scientific-python/action-check-changelogfile/actions) [![Coverage](https://codecov.io/gh/scientific-python/action-check-changelogfile/branch/main/graph/badge.svg)](https://codecov.io/gh/scientific-python/action-check-changelogfile)
+
 Check if a change log entry is present. If present, whether it is in the
 expected section given the milestone. If not, whether it is allowed to
 be missing or not. Create a `.github/workflows/check_changelog_entry.yml`
@@ -27,8 +29,6 @@ jobs:
 Note that adding the environment variable `CHECK_MILESTONE: false` (or anything other than `true`)
 will cause the milestone check to be skipped.
 
-This action uses [astropy-changelog](https://github.com/astropy/astropy-changelog) to parse the change log.
-
 Labels can be applied to the pull request to control its outcome:
 
 * `skip-changelog-checks`: This results in success regardless; same as
@@ -51,10 +51,54 @@ Other ways this action can fail:
 * Change log entry is missing and no special label (see above) is applied to
   indicate that it is expected to be missing.
 
+#### How to run parser locally
+
+While this is not an installable package, you are still able to run the parser
+function if you have this repository checked out locally and you are in the
+same directory as the parser module. Example usage:
+
+```
+>>> from core import load
+>>> changes = load('path/to/CHANGES.rst')
+>>> changes.versions
+['0.1',
+ '0.2',
+ '0.2.1',
+ '0.2.2',
+ '0.2.3',
+ ...]
+>>> changes.issues
+[256,
+ 272,
+ 291,
+ 293,
+ 296,
+ ...]
+>>> changes.versions_for_issue(4242)
+['1.2']
+>>> changes.issues_for_version('2.0.7')
+[7411, 7248, 7402, 7422, 7469, 7486, 7453, 7493, 7510, 7493]
+```
+
+#### Format specification
+
+The current format uses reStructuredText. Changelog entries should be given as
+bullet point items inside sections for each version. These sections should have
+a title with the following syntax:
+
+```
+    version (release date)
+```
+
+The release date can be `unreleased` if the version is not released yet.
+
+The version sections can optionally include sub-sections in which the bullet
+items are organized, and the file can also optionally include an overall title.
+
 #### Why is this not written in TypeScript?
 
 Writing this in TypeScript would make it run much faster. Unfortunately,
-this Action depends on `astropy-changelog`, which was implemented in
+this Action depends on custom change log check logic, which was implemented in
 Python. Therefore, this Action is best done in Python as well and needs
 Docker to run.
 

--- a/check_changelog.py
+++ b/check_changelog.py
@@ -2,8 +2,9 @@ import json
 import os
 import sys
 
-from astropy_changelog import loads
 from github import Github
+
+from core import loads
 
 event_name = os.environ['GITHUB_EVENT_NAME']
 if event_name not in ('pull_request_target', 'pull_request'):
@@ -73,7 +74,7 @@ if len(versions) == 1:
     if check_milestone == 'true':
         if not pr.milestone:
             print(f'Cannot check for consistency of change log in {version} since '
-                'milestone is not set.')
+                  'milestone is not set.')
             sys.exit(1)
 
         milestone = pr.milestone.title
@@ -85,7 +86,7 @@ if len(versions) == 1:
 
         if milestone != version:
             print(f'Changelog entry section ({version}) '
-                f'inconsistent with milestone ({milestone}).')
+                  f'inconsistent with milestone ({milestone}).')
             sys.exit(1)
 
         print(f'Changelog entry consistent with milestone ({milestone}).')

--- a/core.py
+++ b/core.py
@@ -1,0 +1,41 @@
+from rst_parser import RstChangelog
+
+__all__ = ['load', 'loads']
+
+
+def load(filename, format='rst'):
+    """
+    Parse a changelog file.
+
+    Parameters
+    ----------
+    filename : str
+        The changelog file
+    format : { 'rst' }
+        The format of the changelog file (only rst is supported at this time)
+    """
+    if format == 'rst':
+        changelog = RstChangelog()
+        changelog.parse_file(filename)
+        return changelog
+    else:
+        raise ValueError(f'Format not recognized: {format}')
+
+
+def loads(text, format='rst'):
+    """
+    Parse a changelog string.
+
+    Parameters
+    ----------
+    text : str
+        The changelog string
+    format : { 'rst' }
+        The format of the changelog file (only rst is supported at this time)
+    """
+    if format == 'rst':
+        changelog = RstChangelog()
+        changelog.parse_string(text)
+        return changelog
+    else:
+        raise ValueError(f'Format not recognized: {format}')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 
-PYTHON=$(which python3.11)
+PYTHON=$(which python3.10)
 echo "PYTHON=${PYTHON}"
 
 $PYTHON /check_changelog.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 
-PYTHON=$(which python3.8)
+PYTHON=$(which python3.11)
 echo "PYTHON=${PYTHON}"
 
 $PYTHON /check_changelog.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[tool:pytest]
+flake8-ignore = E501

--- a/rst_parser.py
+++ b/rst_parser.py
@@ -1,0 +1,141 @@
+"""A validator for the reStructuredText changelog format."""
+
+import re
+
+import docutils.nodes
+import docutils.parsers.rst
+import docutils.utils
+
+__all__ = ['RstChangelog']
+
+VERSION_PATTERN = re.compile(r'^v?[0-9\.]+ \([\w\-]+\)')
+BLOCK_PATTERN = re.compile(r'\[#.+\]', flags=re.DOTALL)
+ISSUE_PATTERN = re.compile(r'#[0-9]+')
+
+
+def find_prs_in_entry(content):
+    issue_numbers = []
+    for block in BLOCK_PATTERN.finditer(content):
+        block_start, block_end = block.start(), block.end()
+        block = content[block_start:block_end]
+        for m in ISSUE_PATTERN.finditer(block):
+            start, end = m.start(), m.end()
+            issue_numbers.append(int(block[start:end][1:]))
+    return issue_numbers
+
+
+class BulletItemVisitor(docutils.nodes.NodeVisitor):
+
+    def __init__(self, document, warn):
+        super().__init__(document)
+        self.warn = warn
+        self.reset_bullet_items()
+
+    def reset_bullet_items(self):
+        self.bullet_items = []
+
+    def dispatch_visit(self, node):
+        if isinstance(node, docutils.nodes.list_item):
+            self.bullet_items.append(node)
+            raise docutils.nodes.SkipChildren
+        elif isinstance(node, (docutils.nodes.title, docutils.nodes.system_message)):
+            raise docutils.nodes.SkipChildren
+        elif isinstance(node, (docutils.nodes.section, docutils.nodes.bullet_list)):
+            pass
+        else:
+            self.warn(f'Unexpected content: {node.astext()} ({str(type(node))})')
+
+
+class RstChangelog:
+
+    def __init__(self):
+        self.warnings = []
+
+    def warn(self, message):
+        print('WARNING:', message)
+        self.warnings.append(message)
+
+    def _validate_version(self, string):
+        if VERSION_PATTERN.match(string) is None:
+            self.warn(f"Invalid version string: {string}")
+            return
+        return string.split()[0]
+
+    def _parse_observer(self, data):
+        if data['level'] > 1:
+            self.warn(data.children[0].astext())
+        return data
+
+    def parse_file(self, filename):
+        with open(filename) as f:
+            text = f.read()
+        return self.parse_string(text)
+
+    def parse_string(self, text):
+
+        # Parse as rst
+
+        parser = docutils.parsers.rst.Parser()
+        components = (docutils.parsers.rst.Parser, )
+        settings = docutils.frontend.OptionParser(components=components).get_default_values()
+        document = docutils.utils.new_document('<rst-doc>', settings=settings)
+        document.reporter.stream = None
+        document.reporter.attach_observer(self._parse_observer)
+        parser.parse(text, document)
+
+        # At the top level, the document should just include sections whose name is
+        # a version number followed by a release date.
+
+        visitor = BulletItemVisitor(document, self.warn)
+
+        # Some changelogs include a title, which we can just ignore
+        if len(document.children) == 1:
+            title = document[0].attributes['names'][0]
+            if self._validate_version(title) is None:
+                document = document.children[0].children[1:]
+
+        self._issues_by_version = {}
+
+        for section in document:
+
+            title = section.attributes['names'][0]
+            version = self._validate_version(title)
+
+            # Inside each version section there may either directly be a list of
+            # entries, or more nested sections. We use a visitor class to search
+            # for all the bullet point entries, and in the process we make sure
+            # that there are only section titles and bullet point entries in the
+            # section
+
+            visitor.reset_bullet_items()
+            section.walk(visitor)
+
+            # Go over the bullet point items and find the PR numbers
+            issues = []
+            for item in visitor.bullet_items:
+                issues.extend(find_prs_in_entry(item.astext()))
+
+            self._issues_by_version[version] = issues
+
+        self.document = document
+
+    @property
+    def versions(self):
+        return sorted(self._issues_by_version)
+
+    @property
+    def issues(self):
+        all_issues = []
+        for version, issues in self._issues_by_version.items():
+            all_issues.extend(issues)
+        return sorted(set(all_issues))
+
+    def issues_for_version(self, version):
+        return self._issues_by_version[version]
+
+    def versions_for_issue(self, issue):
+        versions = []
+        for version, issues in self._issues_by_version.items():
+            if issue in issues:
+                versions.append(version)
+        return versions

--- a/rst_parser.py
+++ b/rst_parser.py
@@ -76,8 +76,12 @@ class RstChangelog:
         # Parse as rst
 
         parser = docutils.parsers.rst.Parser()
-        components = (docutils.parsers.rst.Parser, )
-        settings = docutils.frontend.OptionParser(components=components).get_default_values()
+        if hasattr(docutils.frontend, 'get_default_settings'):
+            # docutils >= 0.18
+            settings = docutils.frontend.get_default_settings(docutils.parsers.rst.Parser)
+        else:  # pragma: no cover
+            # docutils < 0.18
+            settings = docutils.frontend.OptionParser(components=(docutils.parsers.rst.Parser, )).get_default_values()
         document = docutils.utils.new_document('<rst-doc>', settings=settings)
         document.reporter.stream = None
         document.reporter.attach_observer(self._parse_observer)

--- a/test_data/changes_core.rst
+++ b/test_data/changes_core.rst
@@ -1,0 +1,47 @@
+3.1 (unreleased)
+================
+
+New Features
+------------
+
+astropy.config
+^^^^^^^^^^^^^^
+
+astropy.convolution
+^^^^^^^^^^^^^^^^^^^
+
+- Example entry [#100]
+
+Performance Improvements
+------------------------
+
+- An entry not in a specific subpackage. [#102]
+
+astropy.visualization
+^^^^^^^^^^^^^^^^^^^^^
+
+- An entry in a subpackage. [#103]
+
+3.0.1 (2018-03-12)
+==================
+
+Bug Fixes
+---------
+
+astropy.io.ascii
+^^^^^^^^^^^^^^^^
+
+- A bug fix. [#104]
+
+- An entry that is over
+  multiple lines. [#105]
+
+- An entry with multiple issues. [#106, #107]
+
+- An entry with multiple issues over multiple lines. [#108,
+  #109]
+
+0.1 (2012-06-19)
+================
+
+- Initial release, with no issue.

--- a/test_data/changes_with_title.rst
+++ b/test_data/changes_with_title.rst
@@ -1,0 +1,12 @@
+This changelog has a title
+**************************
+
+1.0 (unreleased)
+================
+
+- Example entry [#100]
+
+0.1 (2012-06-19)
+================
+
+- Initial release, with no issue.

--- a/test_rst_parser.py
+++ b/test_rst_parser.py
@@ -1,0 +1,58 @@
+# Since this is not an installable package, these tests
+# are meant to be run locally.
+
+import os
+
+from core import load, loads
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'test_data')
+
+
+def test_rst_parser():
+
+    changelog = load(os.path.join(DATA_DIR, 'changes_core.rst'))
+
+    assert changelog.versions == ['0.1', '3.0.1', '3.1']
+
+    assert changelog.issues == [100, 102, 103, 104, 105, 106, 107, 108, 109]
+
+    assert changelog.issues_for_version('0.1') == []
+    assert changelog.issues_for_version('3.0.1') == [104, 105, 106, 107, 108, 109]
+    assert changelog.issues_for_version('3.1') == [100, 102, 103]
+
+    for issue in [104, 105, 106, 107, 108, 109]:
+        assert changelog.versions_for_issue(issue) == ['3.0.1']
+
+    for issue in [100, 102, 103]:
+        assert changelog.versions_for_issue(issue) == ['3.1']
+
+
+def test_rst_parser_helpers_style():
+
+    # The astropy-helpers changelog has an overall title and no sub-sections
+    # within versions
+
+    changelog = load(os.path.join(DATA_DIR, 'changes_with_title.rst'))
+
+    assert changelog.versions == ['0.1', '1.0']
+
+    assert changelog.issues == [100]
+
+    assert changelog.issues_for_version('0.1') == []
+    assert changelog.issues_for_version('1.0') == [100]
+    assert changelog.versions_for_issue(100) == ['1.0']
+
+
+SIMPLE_CHANGELOG = ('1.0 (2018-10-22)\n'
+                    '----------------\n'
+                    '* change1 [#1234]\n')
+
+
+def test_short_rst():
+
+    # Regression test for a bug that caused a changelog with only one version section to fail
+
+    changelog = loads(SIMPLE_CHANGELOG)
+
+    assert changelog.versions == ['1.0']
+    assert changelog.issues == [1234]


### PR DESCRIPTION
Fix #3 

I port over as much as possible but I do have to update some code that is ported over if you comparing with https://github.com/astropy/astropy-changelog . @astrofrog is the original author of that package so I added him to license and also as co-author.

- [x] Test this branch as Action downstream before merge. See https://github.com/astropy/astroquery/pull/2786